### PR TITLE
Update for Java 17

### DIFF
--- a/src/main/java/org/coode/mdock/NodeSerialiser.java
+++ b/src/main/java/org/coode/mdock/NodeSerialiser.java
@@ -25,10 +25,15 @@ package org.coode.mdock;
 import java.io.Writer;
 import java.io.IOException;
 
-import com.sun.org.apache.xml.internal.serialize.OutputFormat;
-import com.sun.org.apache.xml.internal.serialize.XMLSerializer;
 import org.w3c.dom.Document;
 
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.TransformerFactoryConfigurationError;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
@@ -70,14 +75,13 @@ public class NodeSerialiser {
         this.writer = writer;
     }
 
-    public void serialise() throws ParserConfigurationException, IOException {
-        OutputFormat of = new OutputFormat();
-        of.setIndent(4);
+    public void serialise() throws ParserConfigurationException, IOException, TransformerFactoryConfigurationError, TransformerException {
         Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
         SerialisationNodeVisitor visitor = new SerialisationNodeVisitor(doc, factory);
         node.accept(visitor);
-        XMLSerializer serializer = new XMLSerializer(writer, of);
-        serializer.serialize(doc);
+        Transformer transformer = TransformerFactory.newInstance().newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.transform(new DOMSource(doc), new StreamResult(writer));
     }
 
 

--- a/src/main/java/org/coode/mdock/examples/ExampleFrame.java
+++ b/src/main/java/org/coode/mdock/examples/ExampleFrame.java
@@ -26,6 +26,9 @@ import org.coode.mdock.*;
 
 import javax.swing.*;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactoryConfigurationError;
+
 import java.util.*;
 import java.awt.event.*;
 import java.io.IOException;
@@ -150,6 +153,12 @@ public class ExampleFrame extends JFrame {
             e1.printStackTrace();
         }
         catch (IOException e1) {
+            e1.printStackTrace();
+        }
+        catch (TransformerFactoryConfigurationError e1) {
+            e1.printStackTrace();
+        }
+        catch (TransformerException e1) {
             e1.printStackTrace();
         }
     }


### PR DESCRIPTION
This patch updates the NodeSerializer class to use the JAX Transformer API instead of internal Java classes -- which may change without notice and are no longer accessible by default in recent Java versions.

This allows _mdock_ to work with Java 17 without having to start the JVM with a `--add-opens java.xml/com.sun.org.apache.xml.internal.serialize=ALL-UNNAMED` option, which is a temporary workaround that is best avoided.